### PR TITLE
✨ Expose 'vendored-openssl' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ async-io = { version = "0.2", default-features = false, features = [] }
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
 pin-utils = { version = "0.1", default-features = false, features = [] }
 
+[features]
+vendored-openssl = ["ssh2/vendored-openssl"]
+
 [workspace]
 members = [
     "demos/smol",


### PR DESCRIPTION
ssh2 / libssh2-sys have a `vendored-openssl` feature that allows building OpenSSL from source rather than use system packages.

When using `async-ssh2-lite`, it can't be enabled at all right now. This adds a `vendored-openssl` feature which enables `ssh2/vendored-openssl`, which in turns enables `libssh2-sys/vendored-openssl`.