### PR TITLE
fix usage of ReadBuf in tokio AsyncRead impls

### DIFF
--- a/async-ssh2-lite/Cargo.toml
+++ b/async-ssh2-lite/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 vendored-openssl = ["ssh2/vendored-openssl"]
 
 _integration_tests = []
+_integration_tests_tokio_ext = []
 
 [dependencies]
 ssh2 = { version = "0.9", default-features = false }

--- a/async-ssh2-lite/src/channel.rs
+++ b/async-ssh2-lite/src/channel.rs
@@ -338,8 +338,20 @@ mod impl_tokio {
             let sess = this.sess.clone();
             let inner = &mut this.inner;
 
-            this.stream
-                .poll_read_with(cx, || inner.read(buf.filled_mut()).map(|_| {}), &sess)
+            this.stream.poll_read_with(
+                cx,
+                || {
+                    let size = inner.read(buf.initialize_unfilled());
+                    match size {
+                        Ok(size) => {
+                            buf.advance(size);
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
+                },
+                &sess,
+            )
         }
     }
 

--- a/async-ssh2-lite/tests/integration_tests/remote_port_forwarding.rs
+++ b/async-ssh2-lite/tests/integration_tests/remote_port_forwarding.rs
@@ -4,7 +4,10 @@ use std::{error, net::SocketAddr};
 
 use async_ssh2_lite::{util::ConnectInfo, AsyncSession};
 use futures_util::future::join_all;
+#[cfg(not(feature = "_integration_tests_tokio_ext"))]
 use futures_util::AsyncReadExt as _;
+#[cfg(feature = "_integration_tests_tokio_ext")]
+use tokio::io::AsyncReadExt as _;
 
 use super::{
     helpers::{get_connect_addr, get_listen_addr, is_internal_test_openssh_server},

--- a/async-ssh2-lite/tests/integration_tests/session__channel_forward_listen.rs
+++ b/async-ssh2-lite/tests/integration_tests/session__channel_forward_listen.rs
@@ -4,7 +4,10 @@ use std::error;
 
 use async_ssh2_lite::{ssh2::ErrorCode, AsyncSession, AsyncSessionStream, Error};
 use futures_util::future::join_all;
+#[cfg(not(feature = "_integration_tests_tokio_ext"))]
 use futures_util::{AsyncReadExt as _, AsyncWriteExt as _};
+#[cfg(feature = "_integration_tests_tokio_ext")]
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 use super::{
     helpers::get_connect_addr, session__userauth_pubkey::__run__session__userauth_pubkey_file,

--- a/async-ssh2-lite/tests/integration_tests/session__scp_send_and_scp_recv.rs
+++ b/async-ssh2-lite/tests/integration_tests/session__scp_send_and_scp_recv.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use async_ssh2_lite::{AsyncSession, AsyncSessionStream};
+#[cfg(not(feature = "_integration_tests_tokio_ext"))]
 use futures_util::{AsyncReadExt as _, AsyncWriteExt as _};
+#[cfg(feature = "_integration_tests_tokio_ext")]
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use rand::{distributions::Alphanumeric, thread_rng, Rng as _};
 use uuid::Uuid;
 

--- a/async-ssh2-lite/tests/run_integration_tests.sh
+++ b/async-ssh2-lite/tests/run_integration_tests.sh
@@ -23,3 +23,4 @@ export SSH_USERNAME="linuxserver.io"
 export SSH_PASSWORD="password"
 
 ${run} ${version} ${listen_port} "cd ${script_path_root}..; cargo test -p async-ssh2-lite --features _integration_tests,async-io,tokio -- --nocapture"
+${run} ${version} ${listen_port} "cd ${script_path_root}..; cargo test -p async-ssh2-lite --features _integration_tests,_integration_tests_tokio_ext,async-io,tokio -- --nocapture"


### PR DESCRIPTION
`ReadBuf` is very confusing to use api. The current code was passing the part of the buffer that was already considered filled by the impl, which means we were continuously overwriting the same section of the buffer with new bytes (actually, in practice the filled part may start out as empty, so we may be filling NO bytes

This pr changes it to:
- initialize the entire readbuf; this requires zero-ing out the buffer, but is required to interact with the underlying `Read` impl safely. This skips the zero-ing on later calls (https://docs.rs/tokio/latest/src/tokio/io/read_buf.rs.html#162)
- Passing the mutable reference to the unfilled section of the buffer to the underlying `Read` impl
- Marking the buffer as filled based on the output of the `Read` impl
  - I *think* we don't need to do any bounds checks as the `Read` impl should do the right thing