### PR TITLE
Bump libssh2-sys from ^0.2 to ^0.3

### DIFF
--- a/async-ssh2-lite/Cargo.toml
+++ b/async-ssh2-lite/Cargo.toml
@@ -22,7 +22,7 @@ _integration_tests_tokio_ext = []
 
 [dependencies]
 ssh2 = { version = "0.9", default-features = false }
-libssh2-sys = { version = "0.2", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["io", "std", "async-await-macro"] }
 async-trait = { version = "0.1", default-features = false }
 


### PR DESCRIPTION
Package `ssh2` is using `libssh2-sys = { version = "^0.3.0" }`, but `async-ssh2-lite` wants to use `{ version = "^0.2.0" }`, which will conflict.