### PR TITLE
Added trace function to AsyncSession

### DIFF
--- a/async-ssh2-lite/src/session.rs
+++ b/async-ssh2-lite/src/session.rs
@@ -8,7 +8,7 @@ use std::os::windows::io::{AsRawSocket, BorrowedSocket};
 
 use ssh2::{
     BlockDirections, DisconnectCode, Error as Ssh2Error, HashType, HostKeyType,
-    KeyboardInteractivePrompt, KnownHosts, MethodType, PublicKey, ScpFileStat, Session,
+    KeyboardInteractivePrompt, KnownHosts, MethodType, PublicKey, ScpFileStat, Session, TraceFlags,
 };
 
 use crate::{
@@ -138,6 +138,10 @@ impl<S> AsyncSession<S> {
 
     pub fn timeout(&self) -> u32 {
         self.inner.timeout()
+    }
+
+    pub fn trace(&self, bitmask: TraceFlags) {
+        self.inner.trace(bitmask)
     }
 }
 


### PR DESCRIPTION
Just exporting the `trace` function from ssh2::Session from AsyncSession, for being able to enable debugging logs from libssh2.